### PR TITLE
Fixed issue with update_scenarios_on_fail initialization

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 max-line-length = 120
 multiline-quotes = '
 docstring-quotes = "
-ignore = T201
+ignore = T201,W504

--- a/rest_api_tester/test.py
+++ b/rest_api_tester/test.py
@@ -156,10 +156,16 @@ class TestCase(unittest.TestCase):
             )
 
             if actual_response:
-                if isinstance(actual_response, str):
-                    scenario['response'] = actual_response
-                else:
+                # TODO: Use case-insensitive dict instead?
+                content_type = (
+                    actual_headers.get('Content-Type') or
+                    actual_headers.get('content-type') or
+                    actual_headers.get('CONTENT-TYPE')
+                )
+                if content_type == 'application/json':
                     scenario['response'] = ujson.loads(actual_response)
+                else:
+                    scenario['response'] = actual_response
             else:
                 scenario.pop('response', None)
 

--- a/rest_api_tester/test.py
+++ b/rest_api_tester/test.py
@@ -50,7 +50,6 @@ class TestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         self.maxDiff = None
-        self.update_scenarios_on_fail = False
 
     def verify_test_result(
         self,
@@ -82,7 +81,7 @@ class TestCase(unittest.TestCase):
 
         update_scenarios_on_fail = any((
             update_scenarios_on_fail,
-            self.update_scenarios_on_fail,
+            getattr(self, 'update_scenarios_on_fail', False),
             Config.UPDATE_SCENARIOS_ON_FAIL
         ))
 

--- a/tests/api/fastapi/__scenarios__/test_fastapi.json
+++ b/tests/api/fastapi/__scenarios__/test_fastapi.json
@@ -49,6 +49,10 @@
         "url": "/items",
         "method": "GET",
         "status": 200,
+        "response_headers": {
+            "content-length": "35",
+            "content-type": "application/json"
+        },
         "response": {
             "items": [
                 {
@@ -168,11 +172,8 @@
         "status": 404
     },
     "test_update_scenarios_on_fail": {
-        "url": "/protected",
+        "url": "/items",
         "method": "GET",
-        "status": 400,
-        "headers": {
-            "secret": "s3cr3t!"
-        }
+        "status": 400
     }
 }

--- a/tests/api/fastapi/test_fastapi.py
+++ b/tests/api/fastapi/test_fastapi.py
@@ -273,31 +273,35 @@ class TestJSON(TestCase):
         self.verify_test_result(result=result)
 
     def test_update_scenarios_on_fail(self) -> None:
-        scenario_file_path = os.path.join(self.runner.path_to_scenarios_dir, 'test_fastapi.json')
-        with open(scenario_file_path, 'r') as f:
-            original_scenario_file_content = f.read()
-
-        with self.assertRaises(Exception):
-            result = self.runner.run(
-                path_to_test_cases='test_fastapi.json',
-                test_name='test_update_scenarios_on_fail'
-            )
-            self.verify_test_result(result=result, update_scenarios_on_fail=True)
-
+        self.items[1] = 'item1'
         try:
+            scenario_file_path = os.path.join(self.runner.path_to_scenarios_dir, 'test_fastapi.json')
             with open(scenario_file_path, 'r') as f:
-                scenario_dict = ujson.loads(f.read())
-                self.assertDictEqual(
-                    scenario_dict['test_get_protected__200'],
-                    scenario_dict['test_update_scenarios_on_fail']
+                original_scenario_file_content = f.read()
+
+            with self.assertRaises(Exception):
+                result = self.runner.run(
+                    path_to_test_cases='test_fastapi.json',
+                    test_name='test_update_scenarios_on_fail'
                 )
-        except Exception:
-            with open(scenario_file_path, 'w+') as f:
-                f.write(original_scenario_file_content)
-            raise
-        else:
-            with open(scenario_file_path, 'w+') as f:
-                f.write(original_scenario_file_content)
+                self.verify_test_result(result=result, update_scenarios_on_fail=True)
+
+            try:
+                with open(scenario_file_path, 'r') as f:
+                    scenario_dict = ujson.loads(f.read())
+                    self.assertDictEqual(
+                        scenario_dict['test_get_items__200_one_item'],
+                        scenario_dict['test_update_scenarios_on_fail']
+                    )
+            except Exception:
+                with open(scenario_file_path, 'w+') as f:
+                    f.write(original_scenario_file_content)
+                raise
+            else:
+                with open(scenario_file_path, 'w+') as f:
+                    f.write(original_scenario_file_content)
+        finally:
+            self.items.clear()
 
     def custom_verifier(self, result: TestResult) -> None:
         # Only check names


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/python-rest-api-tester/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the staging branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
Fixed issue with update_scenarios_on_fail initialization.
Fixed behavior of update_scenarios_on_fail when handling JSON responses.
