### PR TITLE
breaking: Changed how update_scenarios_on_fail writes placeholder text

### DIFF
--- a/rest_api_tester/runner.py
+++ b/rest_api_tester/runner.py
@@ -113,6 +113,9 @@ class TestCaseRunner:
             response_header_modifiers=response_header_modifiers
         )
 
+        test_data.response_json_modifiers = response_json_modifiers
+        test_data.response_header_modifiers = response_header_modifiers
+
         test_data.headers = test_data.headers or {}
         if self.default_content_type and 'content-type' not in test_data.headers:
             test_data.headers['content-type'] = self.default_content_type


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/python-rest-api-tester/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the main branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
`update_scenarios_on_fail` will now update expected values to `update_scenarios_on_fail_options.placeholder_text` when they are modified by `response_json_modifiers` or `response_header_modifiers`