### PR TITLE
fix: Proper parser handling of json modifiers with missing request/response

### DIFF
--- a/rest_api_tester/parser/json_parser.py
+++ b/rest_api_tester/parser/json_parser.py
@@ -52,7 +52,7 @@ class JSONParser(BaseParser):
                 raise Exception('Request format is invalid')
 
         if request_json_modifiers:
-            request_json = ujson.loads(request)
+            request_json = ujson.loads(request or '{}')
             for path, value in request_json_modifiers.items():
                 request_json = utils.json_update(j=request_json, path=path, value=value)
             request = ujson.dumps(request_json)

--- a/rest_api_tester/parser/json_parser.py
+++ b/rest_api_tester/parser/json_parser.py
@@ -76,7 +76,7 @@ class JSONParser(BaseParser):
                 raise Exception('Response format is invalid')
 
         if response_json_modifiers:
-            response_json = ujson.loads(response)
+            response_json = ujson.loads(response or '{}')
             for path, value in response_json_modifiers.items():
                 response_json = utils.json_update(j=response_json, path=path, value=value)
             response = ujson.dumps(response_json)


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/python-rest-api-tester/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the main branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
JSON parser is now properly handling how json modifiers handle missing request/response in scenarios.
