### PR TITLE
fix: Fixed content-type check in default_verifier

### DIFF
--- a/rest_api_tester/test.py
+++ b/rest_api_tester/test.py
@@ -152,11 +152,15 @@ class TestCase(unittest.TestCase):
             raise
 
     def default_verifier(self, result: TestResult) -> None:
-        response_content_type = result.response.headers.get('content-type')
+        response_content_type = (
+            result.response.headers.get('Content-Type') or
+            result.response.headers.get('content-type') or
+            result.response.headers.get('CONTENT-TYPE')
+        )
 
         expected_response = result.test_data.expected_response
         if expected_response:
-            if response_content_type == 'application/json':
+            if 'application/json' in (response_content_type or ''):
                 actual_response = result.response.json
                 if isinstance(actual_response, list):
                     self.assertListEqual(json.loads(expected_response), actual_response)


### PR DESCRIPTION
## Pull Request Checklist

- [X] Make sure to read the contributor guide [here](https://github.com/alexschimpf/python-rest-api-tester/tree/main/CONTRIBUTE.md).
- [X] Make sure you are making a pull request against the main branch.
- [X] Make sure your pull request title matches the requested format.
- [X] Make sure to lint, type-check, and run unit and API tests.

## Description
Fixed issue with content-type detection in `default_verifier` function.
